### PR TITLE
Austin/password fix

### DIFF
--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -46,6 +46,7 @@ export const UPDATE_USER = gql`
     $email: String
     $instruments: String
     $location: String
+    $password: String
   ) {
     updateUser(
       _id: $_id
@@ -54,6 +55,7 @@ export const UPDATE_USER = gql`
       email: $email
       instruments: $instruments
       location: $location
+      password: $password
     ) {
       _id
       firstName

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -14,47 +14,52 @@ const UserSchema = new Schema (
             trim: true
         },
         email: {
-            type: String, 
-            required: true, 
+            type: String,
+            required: true,
             trim: true,
-            unique: true, 
+            unique: true,
             match: [/.+@.+\..+/, "Please enter a valid email address"]
-        }, 
+        },
         password: {
-            type: String, 
-            required: true, 
-            trim: true, 
+            type: String,
+            required: true,
+            trim: true,
             minlength: 8
-        }, 
+        },
         instruments: {
-            type: String, 
-            required: true, 
+            type: String,
+            required: true,
             trim: true
-        }, 
+        },
         location: {
-            type: String, 
-            required: true, 
+            type: String,
+            required: true,
             trim: true
         },
         membershipDate: {
-            type: String, 
+            type: String,
         }
     }
 );
 
-UserSchema.pre('save', async function(next) {
-    if (this.isNew || this.isModified('password')) {
-        const saltRounds = 15; 
-        this.password = await bcrypt.hash(this.password, saltRounds); 
+UserSchema.pre('findOneAndUpdate', async function(next) {
+    const docToUpdate = await this.model.findOne(this.getQuery());
+
+    if (docToUpdate.$isNew || this._update.hasOwnProperty('password')) {
+        const saltRounds = 15;
+
+        const hashedPassword = await bcrypt.hash(docToUpdate.password, saltRounds);
+
+        this._update.password = hashedPassword;
     }
 
-    next(); 
-}); 
+    next();
+});
 
 UserSchema.methods.isCorrectPassword = async function(password) {
-    return bcrypt.compare(password, this.password); 
-}; 
+    return bcrypt.compare(password, this.password);
+};
 
-const User = model('User', UserSchema); 
+const User = model('User', UserSchema);
 
-module.exports = User; 
+module.exports = User;


### PR DESCRIPTION
## Completes Issue #19 

## The Issue

Users are not able to update their password

## The Solution

- Add `password` to the `UpdateUser` mutation on the client side
- Change the `pre('save')` hook in the `User` model to `pre('findOneAndUpdate')`. Per the [mongoose docs](https://mongoosejs.com/docs/middleware.html#notes), the `.save()` hook does not run on `.findOneAndUpdate`, so it was never being called.

## To Test

- Sign in
- Navigate to the forgot password flow
- After saving the password, look up the User in the db and make sure the password is hashed